### PR TITLE
feat: allow orphaned parents

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ const options = {
   dropTarget: node => true, // filter function to specify which parent nodes are valid drop targets
   dropSibling: node => true, // filter function to specify which orphan nodes are valid drop siblings
   newParentNode: (grabbedNode, dropSibling) => ({}), // specifies element json for parent nodes added by dropping an orphan node on another orphan (a drop sibling)
+  allowOrphanedParents: false, // keep the parent node when the last child is removed
   overThreshold: 10, // make dragging over a drop target easier by expanding the hit area by this amount on all sides
   outThreshold: 10 // make dragging out of a drop target a bit harder by expanding the hit area by this amount on all sides
 };

--- a/cytoscape-compound-drag-and-drop.js
+++ b/cytoscape-compound-drag-and-drop.js
@@ -158,6 +158,7 @@ module.exports = {
   newParentNode: function newParentNode(grabbedNode, dropSibling) {
     return {};
   }, // specifies element json for parent nodes added by dropping an orphan node on another orphan (a drop sibling)
+  allowOrphanedParents: false, // keep parent nodes when last child is removed. Useful in combination with newParentNode callback
   overThreshold: 10, // make dragging over a drop target easier by expanding the hit area by this amount on all sides
   outThreshold: 10 // make dragging out of a drop target a bit harder by expanding the hit area by this amount on all sides
 };
@@ -313,8 +314,8 @@ var addListeners = function addListeners() {
         _this.dropTarget.removeClass('cdnd-drop-target');
         _this.dropSibling.removeClass('cdnd-drop-sibling');
 
-        if (_this.dropSibling.nonempty() // remove extension-created parents on out
-        || grabbedIsOnlyChild // remove empty parents
+        if ((_this.dropSibling.nonempty() // remove extension-created parents on out
+        || grabbedIsOnlyChild) && !options.allowOrphanedParents // remove empty parents
         ) {
             _this.dropTarget.remove();
           }
@@ -323,7 +324,9 @@ var addListeners = function addListeners() {
         _this.dropSibling = cy.collection();
         _this.dropTargetBounds = null;
 
-        updateBoundsTuples();
+        if (!options.allowOrphanedParents) {
+          updateBoundsTuples();
+        }
 
         _this.grabbedNode.emit('cdndout', [parent, sibling]);
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5291,7 +5291,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5312,12 +5313,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5332,17 +5335,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5459,7 +5465,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5471,6 +5478,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5485,6 +5493,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5492,12 +5501,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.2.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.1",
             "yallist": "^3.0.0"
@@ -5516,6 +5527,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5596,7 +5608,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5608,6 +5621,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5693,7 +5707,8 @@
         "safe-buffer": {
           "version": "5.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5729,6 +5744,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5748,6 +5764,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5791,12 +5808,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/pages/demo-keep-parents.html
+++ b/pages/demo-keep-parents.html
@@ -1,0 +1,130 @@
+<!DOCTYPE>
+
+<html>
+
+  <head>
+    <title>cytoscape-compound-drag-and-drop demo - real parents</title>
+
+    <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+
+    <script src="https://unpkg.com/cytoscape/dist/cytoscape.min.js"></script>
+
+    <script src="cytoscape-compound-drag-and-drop.js"></script>
+
+    <style>
+      body {
+        font-family: helvetica neue, helvetica, liberation sans, arial, sans-serif;
+        font-size: 14px;
+      }
+
+      .description {
+        max-width: 400px;
+      }
+
+      #cy {
+        height: calc(100% - 8rem);
+      }
+
+      h1 {
+        opacity: 0.5;
+        font-size: 1em;
+        font-weight: bold;
+      }
+
+      #options {
+        z-index: 2;
+        position: absolute;
+        right: 0;
+        top: 0;
+        margin: 0.5em;
+      }
+    </style>
+
+    <script>
+      document.addEventListener('DOMContentLoaded', function(){
+
+        var cy = window.cy = cytoscape({
+          container: document.getElementById('cy'),
+
+          style: [
+            {
+              selector: 'node',
+              style: {
+                'label': 'data(id)'
+              }
+            },
+
+            {
+              selector: 'node:parent',
+              style: {
+                'label': 'data(id)'
+              }
+            },
+
+            {
+              selector: 'edge',
+              style: {
+                'curve-style': 'bezier',
+                'target-arrow-shape': 'triangle'
+              }
+            },
+
+            {
+              selector: '.cdnd-grabbed-node',
+              style: {
+                'background-color': 'red'
+              }
+            },
+
+            {
+              selector: '.cdnd-drop-sibling',
+              style: {
+                'background-color': 'red'
+              }
+            },
+
+            {
+              selector: '.cdnd-drop-target',
+              style: {
+                'border-color': 'red',
+                'border-style': 'dashed'
+              }
+            }
+          ],
+
+          elements: {
+            nodes: [
+              { data: { id: 'a' } },
+              { data: { id: 'b' } },
+              { data: { id: 'c' } },
+              { data: { id: 'd', parent: 'p' } },
+              { data: { id: 'p'} }
+            ],
+            edges: [
+
+            ]
+          }
+        });
+
+        cy.compoundDragAndDrop({
+          newParentNode: (grabbedNode, dropTarget) => {
+            return dropTarget;
+          },
+          allowOrphanedParents: true,
+        });
+      });
+    </script>
+  </head>
+
+  <body>
+    <h1>cytoscape-compound-drag-and-drop demo</h1>
+    <div class="description">
+      <p>
+        cytoscape-compound-drag-and-drop demo using real nodes as parents with <b>allowOrphanedParents</b> and <b>newParentNode</b> callback
+      </p>
+
+    </div>
+    <div id="cy"></div>
+  </body>
+
+</html>

--- a/src/compound-drag-and-drop/defaults.js
+++ b/src/compound-drag-and-drop/defaults.js
@@ -5,6 +5,7 @@ module.exports = {
   dropTarget: node => true, // filter function to specify which parent nodes are valid drop targets
   dropSibling: node => true, // filter function to specify which orphan nodes are valid drop siblings
   newParentNode: (grabbedNode, dropSibling) => ({}), // specifies element json for parent nodes added by dropping an orphan node on another orphan (a drop sibling)
+  allowOrphanedParents: false, // keep parent nodes when last child is removed. Useful in combination with newParentNode callback
   overThreshold: 10, // make dragging over a drop target easier by expanding the hit area by this amount on all sides
   outThreshold: 10 // make dragging out of a drop target a bit harder by expanding the hit area by this amount on all sides
 };

--- a/src/compound-drag-and-drop/listeners.js
+++ b/src/compound-drag-and-drop/listeners.js
@@ -110,8 +110,8 @@ const addListeners = function(){
         this.dropSibling.removeClass('cdnd-drop-sibling');
 
         if(
-          this.dropSibling.nonempty() // remove extension-created parents on out
-          || grabbedIsOnlyChild // remove empty parents
+            (this.dropSibling.nonempty() // remove extension-created parents on out
+          || grabbedIsOnlyChild) && !options.allowOrphanedParents // remove empty parents
         ){
           this.dropTarget.remove();
         }
@@ -120,7 +120,9 @@ const addListeners = function(){
         this.dropSibling = cy.collection();
         this.dropTargetBounds = null;
 
-        updateBoundsTuples();
+        if(!options.allowOrphanedParents) {
+          updateBoundsTuples();
+        }
 
         this.grabbedNode.emit('cdndout', [parent, sibling]);
       }


### PR DESCRIPTION
There is a use case where it is desired to use "real" nodes as parent nodes instead of creating temporary ones.

This can be accomplished with "newParentNode" by returning the dropTarget: 

      newParentNode: (grabbedNode: any, dropTarget: any) => {
        return dropTarget;
      },

The new part is the addition of "allowOrphanedParents" which prevents the parent node from being deleted and allows the last child of a parent to be taken out.