### PR TITLE
feat: added bounding box options

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ const options = {
   dropTarget: (dropTarget, grabbedNode) => true, // filter function to specify which parent nodes are valid drop targets
   dropSibling: (dropSibling, grabbedNode) => true, // filter function to specify which orphan nodes are valid drop siblings
   newParentNode: (grabbedNode, dropSibling) => ({}), // specifies element json for parent nodes added by dropping an orphan node on another orphan (a drop sibling)
+  boundingBoxOptions: { // same as https://js.cytoscape.org/#eles.boundingBox, used when calculating if one node is dragged over another
+    includeOverlays: false,
+    includeLabels: true
+  },
   overThreshold: 10, // make dragging over a drop target easier by expanding the hit area by this amount on all sides
   outThreshold: 10 // make dragging out of a drop target a bit harder by expanding the hit area by this amount on all sides
 };

--- a/src/compound-drag-and-drop/defaults.js
+++ b/src/compound-drag-and-drop/defaults.js
@@ -5,6 +5,10 @@ module.exports = {
   dropTarget: (dropTarget, grabbedNode) => true, // filter function to specify which parent nodes are valid drop targets
   dropSibling: (dropSibling, grabbedNode) => true, // filter function to specify which orphan nodes are valid drop siblings
   newParentNode: (grabbedNode, dropSibling) => ({}), // specifies element json for parent nodes added by dropping an orphan node on another orphan (a drop sibling)
+  boundingBoxOptions: { // same as https://js.cytoscape.org/#eles.boundingBox, used when calculating if one node is dragged over another
+    includeOverlays: false,
+    includeLabels: true
+  },
   overThreshold: 10, // make dragging over a drop target easier by expanding the hit area by this amount on all sides
   outThreshold: 10 // make dragging out of a drop target a bit harder by expanding the hit area by this amount on all sides
 };

--- a/src/compound-drag-and-drop/listeners.js
+++ b/src/compound-drag-and-drop/listeners.js
@@ -22,8 +22,10 @@ const addListeners = function(){
   const canBeDropTarget = n => !isChild(n) && !n.same(this.grabbedNode) && options.dropTarget(n, this.grabbedNode);
   const canBeDropSibling = n => isChild(n) && !n.same(this.grabbedNode) && options.dropSibling(n, this.grabbedNode);
   const canPullFromParent = n => isChild(n);
+  const getBoundTuplesNode = n => getBoundsTuple(n, options.boundingBoxOptions);
+
   const canBeInBoundsTuple = n => (canBeDropTarget(n) || canBeDropSibling(n)) && !n.same(this.dropTarget);
-  const updateBoundsTuples = () => this.boundsTuples = cy.nodes(canBeInBoundsTuple).map(getBoundsTuple);
+  const updateBoundsTuples = () => this.boundsTuples = cy.nodes(canBeInBoundsTuple).map(getBoundTuplesNode);
 
   const reset = () => {
     this.grabbedNode.removeClass('cdnd-grabbed-node');
@@ -50,7 +52,7 @@ const addListeners = function(){
 
     if( canPullFromParent(node) ){
       this.dropTarget = node.parent();
-      this.dropTargetBounds = getBoundsCopy(this.dropTarget);
+      this.dropTargetBounds = getBoundsCopy(this.dropTarget, options.boundingBoxOptions);
     }
 
     updateBoundsTuples();
@@ -67,7 +69,7 @@ const addListeners = function(){
     const newNode = e.target;
 
     if( canBeInBoundsTuple(newNode) ){
-      this.boundsTuples.push( getBoundsTuple(newNode) );
+      this.boundsTuples.push( getBoundsTuple(newNode, options.boundingBoxOptions) );
     }
   });
 
@@ -96,7 +98,7 @@ const addListeners = function(){
     if( !this.inGesture || !this.enabled ){ return; }
 
     if( this.dropTarget.nonempty() ){ // already in a parent
-      const bb = expandBounds( getBounds(this.grabbedNode), options.outThreshold );
+      const bb = expandBounds( getBounds(this.grabbedNode, options.boundingBoxOptions), options.outThreshold );
       const parent = this.dropTarget;
       const sibling = this.dropSibling;
       const rmFromParent = !boundsOverlap(this.dropTargetBounds, bb);
@@ -125,7 +127,7 @@ const addListeners = function(){
         this.grabbedNode.emit('cdndout', [parent, sibling]);
       }
     } else { // not in a parent
-      const bb = expandBounds( getBounds(this.grabbedNode), options.overThreshold );
+      const bb = expandBounds( getBounds(this.grabbedNode, options.boundingBoxOptions), options.overThreshold );
       const tupleOverlaps = t => !t.node.removed() && boundsOverlap(bb, t.bb);
       const overlappingNodes = this.boundsTuples.filter(tupleOverlaps).map(t => t.node);
 
@@ -146,7 +148,7 @@ const addListeners = function(){
 
         setParent(sibling, parent);
 
-        this.dropTargetBounds = getBoundsCopy(parent);
+        this.dropTargetBounds = getBoundsCopy(parent, options.boundingBoxOptions);
 
         setParent(this.grabbedNode, parent);
 

--- a/src/compound-drag-and-drop/util.js
+++ b/src/compound-drag-and-drop/util.js
@@ -2,10 +2,10 @@ const isParent = n => n.isParent();
 const isChild = n => n.isChild();
 const isOnlyChild = n => isChild(n) && n.parent().children().length === 1;
 
-const getBounds = n => n.boundingBox({ includeOverlays: false });
-const getBoundsTuple = n => ({ node: n, bb: copyBounds(getBounds(n)) });
+const getBounds = (n, boundingBoxOptions) => n.boundingBox(boundingBoxOptions);
+const getBoundsTuple = (n, boundingBoxOptions) => ({ node: n, bb: copyBounds(getBounds(n, boundingBoxOptions)) });
 const copyBounds = bb => ({ x1: bb.x1, x2: bb.x2, y1: bb.y1, y2: bb.y2, w: bb.w, h: bb.h });
-const getBoundsCopy = n => copyBounds(getBounds(n));
+const getBoundsCopy = (n, boundingBoxOptions) => copyBounds(getBounds(n, boundingBoxOptions));
 
 const removeParent = n => n.move({ parent: null });
 const setParent = (n, parent) => n.move({ parent: parent.id() });


### PR DESCRIPTION
Based on https://js.cytoscape.org/#eles.boundingBox includeLabels to make sure drag and drop opens only when dragging over the node itself and not over a long title.