### PR TITLE
feat: improve drop check callbacks by adding both nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,8 @@ The `options` object is outlined below with the default values:
 ```js
 const options = {
   grabbedNode: node => true, // filter function to specify which nodes are valid to grab and drop into other nodes
-  dropTarget: node => true, // filter function to specify which parent nodes are valid drop targets
-  dropSibling: node => true, // filter function to specify which orphan nodes are valid drop siblings
+  dropTarget: (dropTarget, grabbedNode) => true, // filter function to specify which parent nodes are valid drop targets
+  dropSibling: (dropSibling, grabbedNode) => true, // filter function to specify which orphan nodes are valid drop siblings
   newParentNode: (grabbedNode, dropSibling) => ({}), // specifies element json for parent nodes added by dropping an orphan node on another orphan (a drop sibling)
   overThreshold: 10, // make dragging over a drop target easier by expanding the hit area by this amount on all sides
   outThreshold: 10 // make dragging out of a drop target a bit harder by expanding the hit area by this amount on all sides

--- a/cytoscape-compound-drag-and-drop.js
+++ b/cytoscape-compound-drag-and-drop.js
@@ -149,10 +149,10 @@ module.exports = {
   grabbedNode: function grabbedNode(node) {
     return true;
   }, // filter function to specify which nodes are valid to grab and drop into other nodes
-  dropTarget: function dropTarget(node) {
+  dropTarget: function dropTarget(_dropTarget, grabbedNode) {
     return true;
   }, // filter function to specify which parent nodes are valid drop targets
-  dropSibling: function dropSibling(node) {
+  dropSibling: function dropSibling(_dropSibling, grabbedNode) {
     return true;
   }, // filter function to specify which orphan nodes are valid drop siblings
   newParentNode: function newParentNode(grabbedNode, dropSibling) {
@@ -205,10 +205,10 @@ var addListeners = function addListeners() {
     return !isParent(n) && !isMultiplySelected(n) && options.grabbedNode(n);
   };
   var canBeDropTarget = function canBeDropTarget(n) {
-    return !isChild(n) && !n.same(_this.grabbedNode) && options.dropTarget(n);
+    return !isChild(n) && !n.same(_this.grabbedNode) && options.dropTarget(n, _this.grabbedNode);
   };
   var canBeDropSibling = function canBeDropSibling(n) {
-    return isChild(n) && !n.same(_this.grabbedNode) && options.dropSibling(n);
+    return isChild(n) && !n.same(_this.grabbedNode) && options.dropSibling(n, _this.grabbedNode);
   };
   var canPullFromParent = function canPullFromParent(n) {
     return isChild(n);

--- a/src/compound-drag-and-drop/defaults.js
+++ b/src/compound-drag-and-drop/defaults.js
@@ -2,8 +2,8 @@
 
 module.exports = {
   grabbedNode: node => true, // filter function to specify which nodes are valid to grab and drop into other nodes
-  dropTarget: node => true, // filter function to specify which parent nodes are valid drop targets
-  dropSibling: node => true, // filter function to specify which orphan nodes are valid drop siblings
+  dropTarget: (dropTarget, grabbedNode) => true, // filter function to specify which parent nodes are valid drop targets
+  dropSibling: (dropSibling, grabbedNode) => true, // filter function to specify which orphan nodes are valid drop siblings
   newParentNode: (grabbedNode, dropSibling) => ({}), // specifies element json for parent nodes added by dropping an orphan node on another orphan (a drop sibling)
   overThreshold: 10, // make dragging over a drop target easier by expanding the hit area by this amount on all sides
   outThreshold: 10 // make dragging out of a drop target a bit harder by expanding the hit area by this amount on all sides

--- a/src/compound-drag-and-drop/listeners.js
+++ b/src/compound-drag-and-drop/listeners.js
@@ -19,8 +19,8 @@ const addListeners = function(){
 
   const isMultiplySelected = n => n.selected() && cy.elements('node:selected').length > 1;
   const canBeGrabbed = n => !isParent(n) && !isMultiplySelected(n) && options.grabbedNode(n);
-  const canBeDropTarget = n => !isChild(n) && !n.same(this.grabbedNode) && options.dropTarget(n);
-  const canBeDropSibling = n => isChild(n) && !n.same(this.grabbedNode) && options.dropSibling(n);
+  const canBeDropTarget = n => !isChild(n) && !n.same(this.grabbedNode) && options.dropTarget(n, this.grabbedNode);
+  const canBeDropSibling = n => isChild(n) && !n.same(this.grabbedNode) && options.dropSibling(n, this.grabbedNode);
   const canPullFromParent = n => isChild(n);
   const canBeInBoundsTuple = n => (canBeDropTarget(n) || canBeDropSibling(n)) && !n.same(this.dropTarget);
   const updateBoundsTuples = () => this.boundsTuples = cy.nodes(canBeInBoundsTuple).map(getBoundsTuple);


### PR DESCRIPTION
Hello,

I am proposing this minor update of both **dropTarget** and **dropSiblings** callbacks:

By passing both the grabbed node and the node target, we allow for a more refined conditions on which node can be dropped upon which other.

I kept the first argument the "target" node to insure compatibility for users who already use these callbacks  