### PR TITLE
All kind of nodes can be dropped inside or besides any other node

### DIFF
--- a/cytoscape-compound-drag-and-drop.js
+++ b/cytoscape-compound-drag-and-drop.js
@@ -217,6 +217,7 @@ var addListeners = function addListeners() {
 
     _this.dropTarget.addClass('cdnd-drop-target');
 
+    console.log("emit('cdndgrab');");
     node.emit('cdndgrab');
   });
   this.addListener('add', 'node', function (e) {
@@ -318,6 +319,7 @@ var addListeners = function addListeners() {
             updateBoundsTuples();
           }
 
+          console.log("emit('cdndout', [" + parent.data('id') + ", " + sibling.data('id') +"]);");
           _this.grabbedNode.emit('cdndout', [parent, sibling]);
 
         }
@@ -339,6 +341,82 @@ var addListeners = function addListeners() {
         return t.node;
     });
 
+
+
+
+    //    console.log("findCrossingEdges(draggedNode)"); 
+
+    // Filter edges based on their intersection with the bounding box
+    crossingEdges= cy.edges().filter(function (edge) {
+      const edgeStart = edge.source().position();
+      const edgeEnd = edge.target().position();
+
+      // Check if any line segment of the edge intersects the bounding box
+      return isPointCloseToSegment(edgeStart, edgeEnd,cursor, 20); 
+    });
+
+
+    console.log("crossingEdges=" + (crossingEdges.length > 0 ? crossingEdges.first().data('id') + " (" + crossingEdges.length + ")" : "-" ));
+
+
+    cy.edges().removeClass("crossedEdge");
+    crossingEdges.addClass("crossedEdge");
+    
+
+    
+
+    function isPointCloseToSegment(p1, p2, q, dist) {
+ 
+
+      // Calculate distance from p1 to p2
+      let distP1P2 = distance(p1, p2);
+
+      // Check distance from q to p1
+      let distQp1 = distance(q, p1);
+      if (distQp1 > distP1P2) {
+        return false;
+      }
+
+      // Check distance from q to p2
+      let distQp2 = distance(q, p2);
+      if (distQp2 > distP1P2) {
+        return false;
+      } 
+
+      // Check if the perpendicular distance is within the given distance
+      return pointToLineDistance(p1, p2, q) <= dist;
+    }
+
+    // Function to calculate the Euclidean distance between two points
+    function distance(p, q) {
+      return Math.sqrt((p.x - q.x) ** 2 + (p.y - q.y) ** 2);
+    }
+
+    // Function to calculate the perpendicular distance from q to the line segment p1-p2
+    function pointToLineDistance(p1, p2, q) {
+      let dx = p2.x - p1.x;
+      let dy = p2.y - p1.y;
+
+      // Handle the case when p1 and p2 are the same point
+      if (dx === 0 && dy === 0) {
+        return distance(p1, q);
+      }
+
+      // Compute the projection factor of q onto the line segment
+      let t = ((q.x - p1.x) * dx + (q.y - p1.y) * dy) / (dx * dx + dy * dy);
+      t = Math.max(0, Math.min(1, t)); // Clamp t to the segment
+
+      // Find the closest point on the line segment to q
+      let closestX = p1.x + t * dx;
+      let closestY = p1.y + t * dy;
+
+      // Calculate the distance from q to the closest point
+      let closestPoint = { x: closestX, y: closestY };
+      return distance(q, closestPoint);
+    }
+
+
+    //--------------------------------------------
 
     var possibleBesidesTargets = _this.boundsTuples.filter(cursorBesidesTuple).map(function (t) {
         return t.node;
@@ -512,6 +590,9 @@ var addListeners = function addListeners() {
         dropTarget = _this.dropTarget,
         dropSibling = _this.dropSibling;
     reset();
+
+
+    console.log("emit('cdnddrop', [" + dropTarget.data('id') + ", " + dropSibling.data('id') + "]);");
     grabbedNode.emit('cdnddrop', [dropTarget, dropSibling]);
   });
 };

--- a/demo.html
+++ b/demo.html
@@ -58,7 +58,16 @@
             {
               selector: 'node:parent',
               style: {
-                'label': ''
+                // Show parents nodes' label
+                'label': 'data(id)'
+              }
+            },
+
+            {
+              selector: 'node:compound',
+              style: {
+                // Show compound nodes' label
+                'label': 'data(id)'
               }
             },
 
@@ -90,18 +99,43 @@
                 'border-color': 'red',
                 'border-style': 'dashed'
               }
+            },
+
+            {
+              selector: '.cdnd-fake-parent',
+              style: {
+                'border-color': 'blue',
+                'border-style': 'dotted'
+              }
             }
           ],
 
           elements: {
             nodes: [
               { data: { id: 'a' } },
+              { data: { id: 'a1', parent: 'a' } },
+              { data: { id: 'a2', parent: 'a' } },
+              { data: { id: 'a3', parent: 'a' } },
+              { data: { id: 'a31', parent: 'a3' } },
+              { data: { id: 'a32', parent: 'a3' } },
               { data: { id: 'b' } },
               { data: { id: 'c' } },
               { data: { id: 'd', parent: 'p' } },
               { data: { id: 'p'} }
             ],
             edges: [
+            
+               {
+                 data: { id: 'ab', source: 'a', target: 'b' }
+               },
+               
+               {
+               data: { id: 'a31c', source: 'a31', target: 'c' }
+               },
+               
+               {
+               data: { id: 'a32a31', source: 'a32', target: 'a31' }
+               },
 
             ]
           }

--- a/demo.html
+++ b/demo.html
@@ -3,7 +3,7 @@
 <html>
 
   <head>
-    <title>cytoscape-compound-drag-and-drop demo</title>
+    <title>LabIg cytoscape-compound-drag-and-drop demo</title>
 
     <meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
 
@@ -73,9 +73,19 @@
 
             {
               selector: 'edge',
-              style: {
+              style: { 
+                 'line-color': 'pink',
                 'curve-style': 'bezier',
                 'target-arrow-shape': 'triangle'
+              }
+            },
+
+            {
+              selector: '.crossedEdge',
+              style: {
+                'line-color': 'green',
+                'border-style': 'dotted',
+                'width': 10,
               }
             },
 
@@ -107,11 +117,14 @@
                 'border-color': 'blue',
                 'border-style': 'dotted'
               }
-            }
+            },
           ],
 
           elements: {
             nodes: [
+              { data: { id: 'p1' } },
+              { data: { id: 'p2' } },
+              { data: { id: 'q' } },
               { data: { id: 'a' } },
               { data: { id: 'a1', parent: 'a' } },
               { data: { id: 'a2', parent: 'a' } },
@@ -124,18 +137,10 @@
               { data: { id: 'p'} }
             ],
             edges: [
-            
-               {
-                 data: { id: 'ab', source: 'a', target: 'b' }
-               },
-               
-               {
-               data: { id: 'a31c', source: 'a31', target: 'c' }
-               },
-               
-               {
-               data: { id: 'a32a31', source: 'a32', target: 'a31' }
-               },
+               { data: { id: 'p1p2', source: 'p1', target: 'p2' } },
+               { data: { id: 'ab', source: 'a', target: 'b' } },               
+               { data: { id: 'a31c', source: 'a31', target: 'c' } },               
+               { data: { id: 'a32a31', source: 'a32', target: 'a31' }},
 
             ]
           }


### PR DESCRIPTION
This pull request introduces some improvements to the compound node dragging and dropping functionality. 

It allows users to also drag **any node** (compound or simple, internal or external)  into or beside any other node: This provides more flexibility in organizing and structuring network graphs.

To ensure optimal placement, the algorithm evaluates the best possible option based on the following criteria:
- Leaving a Parent: If a node is dragged outside its compound parent, will cease that relationship.
- Distance calculation: The algorithm calculates the distance between the cursor and the nearest point of the potential new parent or sibling's bounding rectangle.
- Minimum distance selection: The option with the minimum distance is chosen for the new parent or sibling relationship.

Additional Notes:

Please review the changes and provide any feedback or suggestions.
If you have any questions or require further clarification, feel free to ask.
Thank you for your consideration!